### PR TITLE
add pkg-config and use /usr/share conventions

### DIFF
--- a/CMake/CompilerFlags_Fortran.cmake
+++ b/CMake/CompilerFlags_Fortran.cmake
@@ -209,13 +209,13 @@ endif( Fortran_COMPILER_NAME MATCHES "gfortran" )
 
 
 
-
+execute_process(COMMAND pkg-config --cflags plplotd-f95 OUTPUT_VARIABLE PKG_FLAGS OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 ######################################################################################################################################################
 #  Put everything together:
 ######################################################################################################################################################
 
-set( USER_FLAGS "${OPT_FLAGS} ${LIB_FLAGS} ${CHECK_FLAGS} ${WARN_FLAGS} ${SSE_FLAGS} ${IPO_FLAGS} ${OPENMP_FLAGS} ${STATIC_FLAGS} ${INCLUDE_FLAGS} ${PACKAGE_FLAGS}" )
+set( USER_FLAGS "${OPT_FLAGS} ${LIB_FLAGS} ${CHECK_FLAGS} ${WARN_FLAGS} ${SSE_FLAGS} ${IPO_FLAGS} ${OPENMP_FLAGS} ${STATIC_FLAGS} ${INCLUDE_FLAGS} ${PACKAGE_FLAGS} ${PKG_FLAGS}" )
 
 set( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS_ALL} ${CMAKE_Fortran_FLAGS} ${USER_FLAGS}" )
 set( CMAKE_Fortran_FLAGS_RELEASE "${CMAKE_Fortran_FLAGS_ALL} ${CMAKE_Fortran_FLAGS_RELEASE} ${USER_FLAGS}" )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,8 @@ if( CREATE_SHAREDLIB )
     set_target_properties( PG2PLplot_shared PROPERTIES OUTPUT_NAME "PG2PLplot" )
   endif( COMPILER_SPECIFIC_LIBS )
   set_target_properties( PG2PLplot_shared PROPERTIES Fortran_MODULE_DIRECTORY ${MODULE_DIRECTORY} )
+  execute_process(COMMAND pkg-config --libs plplotd-f95 OUTPUT_VARIABLE PKG_LINK OUTPUT_STRIP_TRAILING_WHITESPACE)
+  target_link_libraries( PG2PLplot_shared ${PKG_LINK}) 
 endif( CREATE_SHAREDLIB )
 
 if( CREATE_STATICLIB )
@@ -84,4 +86,4 @@ endif( CREATE_STATICLIB )
 # Install to destination:
 #   use DIRECTORY rather than TARGETS to allow include/<fortrancompiler>/
 install( DIRECTORY usr/ DESTINATION ${CMAKE_INSTALL_PREFIX} )
-install( FILES src/rgb.txt DESTINATION ${CMAKE_INSTALL_PREFIX}/share/PG2PLplot)
+install( FILES src/rgb.txt DESTINATION ${CMAKE_INSTALL_PREFIX}/share/pg2plplot)


### PR DESCRIPTION
This change makes two changes

1) it uses pkg-config to get flags and libraries
2) it uses all lower case for /usr/share
